### PR TITLE
Initial support of chaining a custom dinput8.dll with the base plugin.

### DIFF
--- a/addons/customdlls/README
+++ b/addons/customdlls/README
@@ -1,0 +1,22 @@
+Custom DLLs to be loaded by the addon plugin should be placed here. Currently, only dinput8.dll is supported.
+
+Example: XInput Plus
+In XInput Plus, 
+1) Select your <PSO-ROOT>\psobb.exe 
+2) On the DirectInput tab, select "Enable DirectInput Output."
+3) Perform your customizations.
+4) Click "Apply." 
+
+XInput Plus created these files:
+- <PSO-ROOT>\dinput.dll
+- <PSO-ROOT>\dinput8.dll
+- <PSO-ROOT>\XInput1_3.dll
+- <PSO-ROOT>\XInputPlus.ini
+
+Move dinput.dll, dinput8.dll, and XInput1_3.dll to addons\customdlls folder. Result should be this:
+- <PSO-ROOT>\addons\customdlls\dinput.dll
+- <PSO-ROOT>\addons\customdlls\dinput8.dll
+- <PSO-ROOT>\addons\customdlls\XInput1_3.dll
+- <PSO-ROOT>\XInputPlus.ini
+
+Then install this base plugin into <PSO-ROOT> folder and you should be set.

--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -306,6 +306,7 @@ static sol::table psolualib_list_addons() {
         if (filename == "..") continue;
         if (filename == ".") continue;
         if (filename == "fonts") continue;
+        if (filename == "customdlls") continue;
         if (find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
             ret.add(filename);
         }


### PR DESCRIPTION
This is a merge of a pull request by @hooty7734 in the original repository. The customdlls folder is under the addons folder and is ignored when loading the list of addons at startup and reload. Currently, this supports only a custom dinput8.dll and no other dlls.

An example for XInputPlus is included in the README in the customdlls folder.