### PR TITLE
Add versioning scheme to lua pso table and fix string format issues.

### DIFF
--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -100,6 +100,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h" />
+    <ClInclude Include="src\version.h" />
     <ClInclude Include="src\d3d8.h" />
     <ClInclude Include="src\d3d8caps.h" />
     <ClInclude Include="src\d3d8types.h" />

--- a/bbmod/bbmod.vcxproj.filters
+++ b/bbmod/bbmod.vcxproj.filters
@@ -169,6 +169,9 @@
     <ClInclude Include="src\lua_psolib.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\version.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="version.rc">

--- a/bbmod/src/imgui_iterator.h
+++ b/bbmod/src/imgui_iterator.h
@@ -580,7 +580,7 @@ END_IMGUI_FUNC
 // Variadic functions aren't suppported but here it is anyway
 IMGUI_FUNCTION(Text)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(Text, fmt)
+CALL_FUNCTION_NO_RET(Text, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          TextV(const char* fmt, va_list args);
 // Unsupported arg type  va_list args
@@ -589,7 +589,7 @@ END_IMGUI_FUNC
 IMGUI_FUNCTION(TextColored)
 IM_VEC_4_ARG(col)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(TextColored, col, fmt)
+CALL_FUNCTION_NO_RET(TextColored, col, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          TextColoredV(const ImVec4& col, const char* fmt, va_list args);
 // Unsupported arg type  va_list args
@@ -597,7 +597,7 @@ END_IMGUI_FUNC
 // Variadic functions aren't suppported but here it is anyway
 IMGUI_FUNCTION(TextDisabled)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(TextDisabled, fmt)
+CALL_FUNCTION_NO_RET(TextDisabled, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          TextDisabledV(const char* fmt, va_list args);
 // Unsupported arg type  va_list args
@@ -605,7 +605,7 @@ END_IMGUI_FUNC
 // Variadic functions aren't suppported but here it is anyway
 IMGUI_FUNCTION(TextWrapped)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(TextWrapped, fmt)
+CALL_FUNCTION_NO_RET(TextWrapped, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          TextWrappedV(const char* fmt, va_list args);
 // Unsupported arg type  va_list args
@@ -620,7 +620,7 @@ END_IMGUI_FUNC
 IMGUI_FUNCTION(LabelText)
 LABEL_ARG(label)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(LabelText, label, fmt)
+CALL_FUNCTION_NO_RET(LabelText, label, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          LabelTextV(const char* label, const char* fmt, va_list args);
 // Unsupported arg type  va_list args
@@ -632,7 +632,7 @@ END_IMGUI_FUNC
 // Variadic functions aren't suppported but here it is anyway
 IMGUI_FUNCTION(BulletText)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(BulletText, fmt)
+CALL_FUNCTION_NO_RET(BulletText, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          BulletTextV(const char* fmt, va_list args);
 // Unsupported arg type  va_list args

--- a/bbmod/src/version.h
+++ b/bbmod/src/version.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#define str(a) #a
+#define xstr(a) str(a)
+
+#define BBMOD_VERSION_MAJOR  3
+#define BBMOD_VERSION_MINOR  5
+#define BBMOD_VERSION_PATCH  0
+#define BBMOD_VERSION_STRING ("v" xstr(BBMOD_VERSION_MAJOR) "." xstr(BBMOD_VERSION_MINOR) "." xstr(BBMOD_VERSION_PATCH))
+


### PR DESCRIPTION
Added version.h and set version to 3.5.0. Lua addons can check if pso.require_version is not nil before using it. Also specified "%s" in the imgui wrapper for functions that support variadic arguments and string formatting. The plugin should always pass a constant string format specifier because the plugin does not support variadic arguments. 