### PR TITLE
Added versioning to the plugin and fixed issues with the format strings to wrapped ImGui functions with variadic arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,5 @@ PSO specific functions are in the `pso` global table.
  * list_directory_files -- list files in the specified directory under the addons directory.
  * set_language -- used by the Settings Editor to set the internal language for addons.
  * get_language -- retrieves the language value for addons to handle translation.
+ * get_version -- returns a table containing fields `version_string`, `major`, `minor`, and `patch`. The latter three are integer values corresponding to the plugin's version number. The `version_string` is a string representation.
+ * require_version -- accepts three arguments specifying the version and returns true if the plugin's version is at that level or higher.

--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -100,6 +100,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="resource.h" />
+    <ClInclude Include="src\version.h" />
     <ClInclude Include="src\d3d8.h" />
     <ClInclude Include="src\d3d8caps.h" />
     <ClInclude Include="src\d3d8types.h" />

--- a/bbmod/bbmod.vcxproj.filters
+++ b/bbmod/bbmod.vcxproj.filters
@@ -169,6 +169,9 @@
     <ClInclude Include="src\lua_psolib.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\version.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="version.rc">

--- a/bbmod/src/imgui_iterator.h
+++ b/bbmod/src/imgui_iterator.h
@@ -580,7 +580,7 @@ END_IMGUI_FUNC
 // Variadic functions aren't suppported but here it is anyway
 IMGUI_FUNCTION(Text)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(Text, fmt)
+CALL_FUNCTION_NO_RET(Text, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          TextV(const char* fmt, va_list args);
 // Unsupported arg type  va_list args
@@ -589,7 +589,7 @@ END_IMGUI_FUNC
 IMGUI_FUNCTION(TextColored)
 IM_VEC_4_ARG(col)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(TextColored, col, fmt)
+CALL_FUNCTION_NO_RET(TextColored, col, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          TextColoredV(const ImVec4& col, const char* fmt, va_list args);
 // Unsupported arg type  va_list args
@@ -597,7 +597,7 @@ END_IMGUI_FUNC
 // Variadic functions aren't suppported but here it is anyway
 IMGUI_FUNCTION(TextDisabled)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(TextDisabled, fmt)
+CALL_FUNCTION_NO_RET(TextDisabled, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          TextDisabledV(const char* fmt, va_list args);
 // Unsupported arg type  va_list args
@@ -605,7 +605,7 @@ END_IMGUI_FUNC
 // Variadic functions aren't suppported but here it is anyway
 IMGUI_FUNCTION(TextWrapped)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(TextWrapped, fmt)
+CALL_FUNCTION_NO_RET(TextWrapped, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          TextWrappedV(const char* fmt, va_list args);
 // Unsupported arg type  va_list args
@@ -620,7 +620,7 @@ END_IMGUI_FUNC
 IMGUI_FUNCTION(LabelText)
 LABEL_ARG(label)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(LabelText, label, fmt)
+CALL_FUNCTION_NO_RET(LabelText, label, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          LabelTextV(const char* label, const char* fmt, va_list args);
 // Unsupported arg type  va_list args
@@ -632,7 +632,7 @@ END_IMGUI_FUNC
 // Variadic functions aren't suppported but here it is anyway
 IMGUI_FUNCTION(BulletText)
 LABEL_ARG(fmt)
-CALL_FUNCTION_NO_RET(BulletText, fmt)
+CALL_FUNCTION_NO_RET(BulletText, "%s", fmt)
 END_IMGUI_FUNC
 //    IMGUI_API void          BulletTextV(const char* fmt, va_list args);
 // Unsupported arg type  va_list args

--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -6,6 +6,7 @@
 #include "lua_hooks.h"
 #include "luastate.h"
 #include "log.h"
+#include "version.h"
 #include "wrap_imgui_impl.h"
 #define PSOBB_HWND_PTR (HWND*)(0x00ACBED8 - 0x00400000 + g_PSOBaseAddress)
 static int wrap_exceptions(lua_State *L, lua_CFunction f);
@@ -20,6 +21,8 @@ static void psolualib_change_global_font(std::string font_name, float font_size,
 static sol::table psolualib_list_font_files();
 static void psolualib_set_language(std::string lang = "EN");
 static std::string psolualib_get_language();
+static sol::table psolualib_get_version();
+static bool psolualib_require_version(int major, int minor, int patch);
 
 bool psolua_initialize_on_next_frame = false;
 
@@ -184,6 +187,8 @@ void psolua_load_library(lua_State * L) {
     psoTable["list_font_files"] = psolualib_list_font_files;
     psoTable["set_language"] = psolualib_set_language;
     psoTable["get_language"] = psolualib_get_language;
+    psoTable["get_version"] = psolualib_get_version;
+    psoTable["require_version"] = psolualib_require_version;
     lua["print"]("PSOBB Base address is ", g_PSOBaseAddress);
 
     // Exception handling
@@ -480,4 +485,42 @@ void psolualib_set_language(std::string lang) {
 
 std::string psolualib_get_language() {
     return g_LanguageSetting;
+}
+
+// Returns false on error or if version specified by t is lower than current.
+// Returns true if the specified version is greater or equal to the plugin's version.
+static bool psolualib_require_version(int major, int minor, int patch) {
+
+    if (BBMOD_VERSION_MAJOR < major)
+        return false; 
+    if (BBMOD_VERSION_MAJOR > major)
+        return true;
+
+    // major matches, check minor and patch
+    if (BBMOD_VERSION_MINOR < minor)
+        return false;
+    if (BBMOD_VERSION_MINOR > minor)
+        return true;
+
+    // major and minor match, check patch
+    if (BBMOD_VERSION_PATCH < patch)
+        return false;
+    if (BBMOD_VERSION_PATCH >= patch)
+        return true;
+
+    // doesn't get here
+    return false;
+}
+
+// Returns the version inside a table.
+static sol::table psolualib_get_version() {
+    sol::state_view lua(g_LuaState);
+    sol::table ret = lua.create_table();
+
+    ret["version_string"] = std::string(BBMOD_VERSION_STRING);
+    ret["major"] = BBMOD_VERSION_MAJOR;
+    ret["minor"] = BBMOD_VERSION_MINOR;
+    ret["patch"] = BBMOD_VERSION_PATCH;
+
+    return ret;
 }

--- a/bbmod/src/version.h
+++ b/bbmod/src/version.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#define str(a) #a
+#define xstr(a) str(a)
+
+#define BBMOD_VERSION_MAJOR  3
+#define BBMOD_VERSION_MINOR  5
+#define BBMOD_VERSION_PATCH  0
+#define BBMOD_VERSION_STRING ("v" xstr(BBMOD_VERSION_MAJOR) "." xstr(BBMOD_VERSION_MINOR) "." xstr(BBMOD_VERSION_PATCH))
+


### PR DESCRIPTION
Wrapped ImGui functions with support for string formatting specify "%s" for the format string and pass the string as the first argument. The plugin does not support variadic arguments and requires any string formatting to be done in lua using string.format. This change fixes issues where imgui.Text("%i") will perform a substitution inside ImGui.