### PR TITLE
Fix minor version number.

### DIFF
--- a/bbmod/src/version.h
+++ b/bbmod/src/version.h
@@ -4,7 +4,7 @@
 #define xstr(a) str(a)
 
 #define BBMOD_VERSION_MAJOR  3
-#define BBMOD_VERSION_MINOR  5
+#define BBMOD_VERSION_MINOR  6
 #define BBMOD_VERSION_PATCH  0
 #define BBMOD_VERSION_STRING ("v" xstr(BBMOD_VERSION_MAJOR) "." xstr(BBMOD_VERSION_MINOR) "." xstr(BBMOD_VERSION_PATCH))
 


### PR DESCRIPTION
Following current convention of release tagging where current release is v0.3.5.6, but we're ignoring the 0 for now.