### PR TITLE
Fix the color button tooltips to show #AARRGGBB

### DIFF
--- a/addons/Theme Editor/init.lua
+++ b/addons/Theme Editor/init.lua
@@ -248,10 +248,10 @@ local function PresentColorEditor(label, default, custom)
         imgui.SetTooltip(
             string.format(
                 "#%02X%02X%02X%02X",
-                i_custom[4],
                 i_custom[1],
                 i_custom[2],
-                i_custom[3]
+                i_custom[3],
+                i_custom[4]
             )
         )
     end


### PR DESCRIPTION
The string.format argument order would have been correct if i_custom elements were in RGBA order but they're in ARGB (What the tooltip was showing was #BBAARRGG).