### PR TITLE
Fix theme.ini parsing bug where certain colors are read incorrectly

### DIFF
--- a/addons/Theme Editor/init.lua
+++ b/addons/Theme Editor/init.lua
@@ -42,16 +42,6 @@ function LIP.load(fileName)
         end
         local param, value = line:match('^([%w|_]+)%s-=%s-(.+)$');
         if(param and value ~= nil)then
-            if(tonumber(value))then
-                value = tonumber(value);
-            elseif(value == 'true')then
-                value = true;
-            elseif(value == 'false')then
-                value = false;
-            end
-            if(tonumber(param))then
-                param = tonumber(param);
-            end
             data[section][param] = value;
         end
     end
@@ -339,7 +329,7 @@ local function init()
     return
     {
         name = "Theme Editor",
-        version = "1.1.0",
+        version = "1.1.1",
         author = "Solybum",
         description = "Theme editor for framework global theme",
         present = present,


### PR DESCRIPTION
In `LIP.load` when the ini color has [A-Fa-f] characters and no 0x/0X prefix tonumber() defaults to base 10 and usually fails, and the color stays unchanged as a string. But when the literal has exactly one "e" or "E" and only 0-9 otherwise, tonumber() parses it successfully as the exponent delimiter of a decimal literal.

Example: default color for `Header=726666E5` gets parsed as decimal `726666 x 10^5`

(noticed the bug when the theme editor always showed a revert button after revert+save+reload for `Header` specifically)

Fix removes type conversion code from LIP.load and let everything stay stringly-typed initially; addon code correctly handles it later with tonumber(..., 16).