### PR TITLE
Add image loading API and texture handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,23 @@ PSO specific functions are in the `pso` global table.
  * get_language -- retrieves the language value for addons to handle translation.
  * get_version -- returns a table containing fields `version_string`, `major`, `minor`, and `patch`. The latter three are integer values corresponding to the plugin's version number. The `version_string` is a string representation.
  * require_version -- accepts three arguments specifying the version and returns true if the plugin's version is at that level or higher.
+ * load_texture(path) -- load an image file (PNG, JPG, BMP, GIF, TIFF, etc. — anything WIC supports) and return a texture handle. Returns `handle, width, height` on success, or `nil, error_message` on failure. The handle is a lightuserdata wrapping a D3D8 texture and can be passed directly to `imgui.Image` / `imgui.ImageButton`. Path is relative to the PSOBB install directory (e.g. `"addons/MyAddon/icon.png"`).
+ * unload_texture(handle) -- release a texture handle previously returned by `load_texture`. All textures are also released automatically when the Lua state is reloaded via `pso.reload()`.
+
+### Displaying images in an addon
+
+```lua
+local tex, w, h = pso.load_texture("addons/MyAddon/logo.png")
+if tex then
+    imgui.Image(tex, w, h)
+end
+```
+
+For caching and a friendlier API, see `addons/solylib/image.lua`:
+
+```lua
+local image = require("solylib.image")
+image.Draw("addons/MyAddon/logo.png")        -- native size
+image.Draw("addons/MyAddon/logo.png", 64, 64) -- explicit size
+if image.Button("addons/MyAddon/btn.png", 32, 32) then ... end
+```

--- a/bbmod/bbmod.vcxproj
+++ b/bbmod/bbmod.vcxproj
@@ -91,6 +91,7 @@
     <ClCompile Include="src\log.cpp" />
     <ClCompile Include="src\luastate.cpp" />
     <ClCompile Include="src\lua_hooks.cpp" />
+    <ClCompile Include="src\lua_image.cpp" />
     <ClCompile Include="src\lua_psolib.cpp" />
     <ClCompile Include="src\util.cpp" />
     <ClCompile Include="src\wrap_imgui_impl.cpp" />
@@ -125,6 +126,7 @@
     <ClInclude Include="src\luajit\lualib.h" />
     <ClInclude Include="src\luastate.h" />
     <ClInclude Include="src\lua_hooks.h" />
+    <ClInclude Include="src\lua_image.h" />
     <ClInclude Include="src\lua_psolib.h" />
     <ClInclude Include="src\minhook.h" />
     <ClInclude Include="src\physfs.h" />

--- a/bbmod/bbmod.vcxproj.filters
+++ b/bbmod/bbmod.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="src\lua_hooks.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\lua_image.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\lua_psolib.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -164,6 +167,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\lua_hooks.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\lua_image.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\lua_psolib.h">

--- a/bbmod/src/imgui_impl_d3d8.cpp
+++ b/bbmod/src/imgui_impl_d3d8.cpp
@@ -536,6 +536,10 @@ void ImGui_ImplD3D8_Shutdown(void) {
 
 }
 
+IDirect3DDevice8* ImGui_ImplD3D8_GetDevice(void) {
+    return g_device;
+}
+
 void ImGui_ImplD3D8_NewFrame(void) {
     if (!g_FontTexture || !g_DepthBuffer)
         ImGui_ImplDX9_CreateDeviceObjects();

--- a/bbmod/src/imgui_impl_d3d8.h
+++ b/bbmod/src/imgui_impl_d3d8.h
@@ -9,3 +9,4 @@ bool ImGui_ImplD3D8_Init(void* hwnd, IDirect3DDevice8** device);
 void ImGui_ImplD3D8_Shutdown(void);
 void ImGui_ImplD3D8_NewFrame(void);
 void ImGui_BetweenFrameChanges(void);
+IDirect3DDevice8* ImGui_ImplD3D8_GetDevice(void);

--- a/bbmod/src/lua_image.cpp
+++ b/bbmod/src/lua_image.cpp
@@ -1,0 +1,173 @@
+#include "lua_image.h"
+
+#include <Windows.h>
+#include <wincodec.h>
+#include <unordered_set>
+#include <cstdint>
+
+#include "d3d8.h"
+#include "imgui_impl_d3d8.h"
+#include "log.h"
+
+#define LUA_COMPAT_ALL
+#include "luajit/lua.hpp"
+
+#pragma comment(lib, "windowscodecs.lib")
+#pragma comment(lib, "ole32.lib")
+
+// Tracks every texture created via pso.load_texture so we can release them
+// on Lua state reload or process shutdown.
+static std::unordered_set<LPDIRECT3DTEXTURE8> g_loaded_textures;
+
+static LPDIRECT3DTEXTURE8 LoadTextureFromFile_WIC(const wchar_t* wpath, UINT* outW, UINT* outH) {
+    IDirect3DDevice8* device = ImGui_ImplD3D8_GetDevice();
+    if (!device) {
+        return nullptr;
+    }
+
+    HRESULT hr = S_OK;
+    IWICImagingFactory* factory = nullptr;
+    IWICBitmapDecoder* decoder = nullptr;
+    IWICBitmapFrameDecode* frame = nullptr;
+    IWICFormatConverter* converter = nullptr;
+    LPDIRECT3DTEXTURE8 texture = nullptr;
+    UINT width = 0, height = 0;
+    D3DLOCKED_RECT locked = { 0 };
+    bool locked_ok = false;
+
+    HRESULT coInit = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    bool needCoUninit = SUCCEEDED(coInit);
+
+    hr = CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
+        IID_IWICImagingFactory, reinterpret_cast<LPVOID*>(&factory));
+    if (FAILED(hr)) goto cleanup;
+
+    hr = factory->CreateDecoderFromFilename(wpath, nullptr, GENERIC_READ,
+        WICDecodeMetadataCacheOnLoad, &decoder);
+    if (FAILED(hr)) goto cleanup;
+
+    hr = decoder->GetFrame(0, &frame);
+    if (FAILED(hr)) goto cleanup;
+
+    hr = frame->GetSize(&width, &height);
+    if (FAILED(hr)) goto cleanup;
+
+    hr = factory->CreateFormatConverter(&converter);
+    if (FAILED(hr)) goto cleanup;
+
+    // Convert to 32bpp BGRA which matches D3DFMT_A8R8G8B8 byte layout on Windows.
+    hr = converter->Initialize(frame, GUID_WICPixelFormat32bppBGRA,
+        WICBitmapDitherTypeNone, nullptr, 0.0, WICBitmapPaletteTypeCustom);
+    if (FAILED(hr)) goto cleanup;
+
+    hr = device->CreateTexture(width, height, 1, 0, D3DFMT_A8R8G8B8,
+        D3DPOOL_MANAGED, &texture);
+    if (FAILED(hr)) {
+        texture = nullptr;
+        goto cleanup;
+    }
+
+    hr = texture->LockRect(0, &locked, nullptr, 0);
+    if (FAILED(hr)) goto cleanup;
+    locked_ok = true;
+
+    {
+        WICRect rect = { 0, 0, static_cast<INT>(width), static_cast<INT>(height) };
+        hr = converter->CopyPixels(&rect, locked.Pitch, locked.Pitch * height,
+            static_cast<BYTE*>(locked.pBits));
+    }
+
+cleanup:
+    if (locked_ok && texture) {
+        texture->UnlockRect(0);
+    }
+    if (FAILED(hr) && texture) {
+        texture->Release();
+        texture = nullptr;
+    }
+    if (converter) converter->Release();
+    if (frame) frame->Release();
+    if (decoder) decoder->Release();
+    if (factory) factory->Release();
+    if (needCoUninit) CoUninitialize();
+
+    if (texture) {
+        if (outW) *outW = width;
+        if (outH) *outH = height;
+    }
+    return texture;
+}
+
+static int lua_load_texture(lua_State* L) {
+    size_t pathlen = 0;
+    const char* path = luaL_checklstring(L, 1, &pathlen);
+
+    wchar_t wpath[MAX_PATH] = { 0 };
+    int n = MultiByteToWideChar(CP_UTF8, 0, path, static_cast<int>(pathlen),
+        wpath, MAX_PATH - 1);
+    if (n <= 0) {
+        // Fall back to ANSI/system codepage if UTF-8 conversion failed.
+        n = MultiByteToWideChar(CP_ACP, 0, path, static_cast<int>(pathlen),
+            wpath, MAX_PATH - 1);
+        if (n <= 0) {
+            lua_pushnil(L);
+            lua_pushfstring(L, "failed to convert path: %s", path);
+            return 2;
+        }
+    }
+    // wpath is already zero-initialized; MultiByteToWideChar with an explicit
+    // input length does not null-terminate, but the trailing zeros from the
+    // array initializer serve as the terminator.
+
+    UINT width = 0, height = 0;
+    LPDIRECT3DTEXTURE8 tex = LoadTextureFromFile_WIC(wpath, &width, &height);
+    if (!tex) {
+        lua_pushnil(L);
+        lua_pushfstring(L, "failed to load image: %s", path);
+        return 2;
+    }
+
+    g_loaded_textures.insert(tex);
+
+    lua_pushlightuserdata(L, static_cast<void*>(tex));
+    lua_pushinteger(L, static_cast<lua_Integer>(width));
+    lua_pushinteger(L, static_cast<lua_Integer>(height));
+    return 3;
+}
+
+static int lua_unload_texture(lua_State* L) {
+    int t = lua_type(L, 1);
+    if (t == LUA_TNIL || t == LUA_TNONE) {
+        return 0;
+    }
+    if (t != LUA_TLIGHTUSERDATA && t != LUA_TUSERDATA) {
+        return luaL_argerror(L, 1, "expected texture handle (lightuserdata)");
+    }
+    LPDIRECT3DTEXTURE8 tex = static_cast<LPDIRECT3DTEXTURE8>(lua_touserdata(L, 1));
+    auto it = g_loaded_textures.find(tex);
+    if (it != g_loaded_textures.end()) {
+        tex->Release();
+        g_loaded_textures.erase(it);
+    }
+    return 0;
+}
+
+void psolua_register_image_library(lua_State* L) {
+    lua_getglobal(L, "pso");
+    if (lua_isnil(L, -1)) {
+        lua_pop(L, 1);
+        return;
+    }
+    lua_pushcfunction(L, lua_load_texture);
+    lua_setfield(L, -2, "load_texture");
+    lua_pushcfunction(L, lua_unload_texture);
+    lua_setfield(L, -2, "unload_texture");
+    lua_pop(L, 1);
+}
+
+void psolua_release_all_textures(void) {
+    for (LPDIRECT3DTEXTURE8 tex : g_loaded_textures) {
+        if (tex) tex->Release();
+    }
+    g_loaded_textures.clear();
+}

--- a/bbmod/src/lua_image.h
+++ b/bbmod/src/lua_image.h
@@ -1,0 +1,6 @@
+#pragma once
+
+struct lua_State;
+
+void psolua_register_image_library(struct lua_State* L);
+void psolua_release_all_textures(void);

--- a/bbmod/src/lua_psolib.cpp
+++ b/bbmod/src/lua_psolib.cpp
@@ -8,6 +8,7 @@
 #include "log.h"
 #include "version.h"
 #include "wrap_imgui_impl.h"
+#include "lua_image.h"
 #define PSOBB_HWND_PTR (HWND*)(0x00ACBED8 - 0x00400000 + g_PSOBaseAddress)
 static int wrap_exceptions(lua_State *L, lua_CFunction f);
 static int psolua_print(lua_State *L);
@@ -198,10 +199,17 @@ void psolua_load_library(lua_State * L) {
 
     // ImGui library
     luaopen_imgui(L);
+
+    // Image / texture loading API (pso.load_texture, pso.unload_texture)
+    psolua_register_image_library(L);
 }
 
 void psolua_initialize_state(void) {
     if (g_LuaState != nullptr) {
+        // Release any textures created by the previous Lua state. The
+        // lightuserdata handles held by addons become invalid here, but
+        // since the state itself is being torn down that's expected.
+        psolua_release_all_textures();
         lua_close(g_LuaState);
         g_LuaState = nullptr;
     }

--- a/bbmod/src/wrap_imgui_impl.cpp
+++ b/bbmod/src/wrap_imgui_impl.cpp
@@ -33,7 +33,6 @@
 ** Love implentation functions
 */
 static bool g_inited = false;
-static int	g_textures[250]; // Should be enough
 
 /*
 ** Wrapped functions
@@ -45,17 +44,22 @@ static int impl_##name(lua_State *L) { \
   int arg = 1; \
   int stackval = 0;
 
+// Accept a texture handle from Lua. pso.load_texture returns a lightuserdata
+// holding an LPDIRECT3DTEXTURE8 pointer; we also accept a number for callers
+// that already have a raw pointer value.
 #define TEXTURE_ARG(name) \
-    lua_getglobal(L, "imgui"); \
-    lua_pushvalue(L, arg++); \
-    lua_setfield(L, -2, "textureID"); \
-    luaL_dostring(L, "imgui.textures = imgui.textures or {}\
-                      table.insert(imgui.textures, imgui.textureID)\
-                      return #imgui.textures"); \
-    lua_pop(L, 1); \
-    int index = luaL_checkint(L, 0);\
-    g_textures[index - 1] = index; \
-    void *name = &g_textures[index - 1]; \
+  void *name = NULL; \
+  { \
+    int _tex_t = lua_type(L, arg); \
+    if (_tex_t == LUA_TLIGHTUSERDATA || _tex_t == LUA_TUSERDATA) { \
+      name = lua_touserdata(L, arg++); \
+    } else if (_tex_t == LUA_TNUMBER) { \
+      name = (void*)(uintptr_t)lua_tointeger(L, arg++); \
+    } else { \
+      luaL_argerror(L, arg, "expected texture handle from pso.load_texture"); \
+      arg++; \
+    } \
+  }
 
 #define OPTIONAL_LABEL_ARG(name, value) \
   const char* name; \


### PR DESCRIPTION
Adds `pso.load_texture` / `pso.unload_texture` so addons can display PNG/JPG (and anything else WIC decodes) via `imgui.Image` / `imgui.ImageButton`. The existing image bindings were stubs — `TEXTURE_ARG` stored Lua-side indices into a global int array and handed that address to D3D8, which never produced a valid texture. This PR makes those bindings actually work and adds the loader they were missing.

### Lua API

- `pso.load_texture(path)` → `handle, width, height` on success; `nil, error_message` on failure. Handle is a `lightuserdata` wrapping `LPDIRECT3DTEXTURE8`.
- `pso.unload_texture(handle)` releases a single texture.
- All outstanding textures are released automatically on `pso.reload()` via the new `psolua_release_all_textures()`, so addons don't have to clean up on hot reload.

### Changes

- **New** `bbmod/src/lua_image.{h,cpp}`: WIC decode → BGRA → `D3DFMT_A8R8G8B8` in `D3DPOOL_MANAGED` (survives device reset / alt-tab without recreation), Lua bindings, and a tracking set for shutdown.
- **`imgui_impl_d3d8.{h,cpp}`**: expose `ImGui_ImplD3D8_GetDevice()` so the loader can call `CreateTexture` on the live device.
- **`wrap_imgui_impl.cpp`**: rewrite `TEXTURE_ARG` to unwrap a `lightuserdata` (or number, as a fallback) and pass the real pointer through to `ImGui::Image`. Removes the dead `g_textures[250]` global.
- **`lua_psolib.cpp`**: register the image library after `luaopen_imgui`; call `psolua_release_all_textures()` before `lua_close` during state reload.
- **`bbmod.vcxproj` / `.filters`**: include the new sources. `windowscodecs.lib` and `ole32.lib` are pulled in via `#pragma comment(lib, ...)` from `lua_image.cpp`.
- **`README.md`**: documents the new `pso.*` functions with a usage snippet.

### Usage

```lua
local tex, w, h = pso.load_texture("addons/MyAddon/icon.png")
if tex then imgui.Image(tex, w, h) end
```

I started tinkering with this seeing I would love to add secid images into the chat addon as well as some other addons. 
<img width="223" height="116" alt="image" src="https://github.com/user-attachments/assets/2ad3e526-4549-4614-bdae-a42658b1a87f" />




